### PR TITLE
Renamed windows headers to their actual case sensitive names

### DIFF
--- a/luasec/ext.manifest
+++ b/luasec/ext.manifest
@@ -24,8 +24,8 @@ platforms:
   
     x86-win32:
         context:
-            libs:       ["Crypt32.Lib"]
+            libs:       ["Crypt32"]
 
     x86_64-win32:
         context:
-            libs:       ["Crypt32.Lib"]
+            libs:       ["Crypt32"]

--- a/luasec/include/luasocket/wsocket.h
+++ b/luasec/include/luasocket/wsocket.h
@@ -8,9 +8,9 @@
 /*=========================================================================*\
 * WinSock include files
 \*=========================================================================*/
-//#include <winsock2.h>
-#include <ws2tcpip.h>
-//#include <windows.h>
+//#include <WinSock2.h>
+#include <WS2tcpip.h>
+//#include <Windows.h>
 
 typedef int socklen_t;
 typedef SOCKADDR_STORAGE t_sockaddr_storage;

--- a/luasec/src/context.c
+++ b/luasec/src/context.c
@@ -10,8 +10,8 @@
 #include <string.h>
 
 #if defined(WIN32)
-#include <Winsock2.h>
-//#include <windows.h>
+#include <WinSock2.h>
+//#include <Windows.h>
 #endif
 
 #include "openssl/ssl.h"

--- a/luasec/src/luasec.cpp
+++ b/luasec/src/luasec.cpp
@@ -1,8 +1,8 @@
 
 
 #if defined(WIN32)
-#include <Winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #endif
 
 // include the Defold SDK

--- a/luasec/src/luasocket/timeout.c
+++ b/luasec/src/luasocket/timeout.c
@@ -7,8 +7,8 @@
 #include <float.h>
 
 #ifdef _WIN32
-#include <Winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #endif
 
 //#include "lua.h"

--- a/luasec/src/luasocket/wsocket.c
+++ b/luasec/src/luasocket/wsocket.c
@@ -7,8 +7,8 @@
 * the I/O call fail in the first place. 
 \*=========================================================================*/
 #include <string.h>
-#include <Winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 
 #include "luasocket/socket.h"
 

--- a/luasec/src/ssl.c
+++ b/luasec/src/ssl.c
@@ -11,8 +11,8 @@
 #include <string.h>
 
 #if defined(WIN32)
-#include <Winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #endif
 
 #include "openssl/ssl.h"

--- a/luasec/src/x509.c
+++ b/luasec/src/x509.c
@@ -10,8 +10,8 @@
 #include <string.h>
 
 #if defined(WIN32)
-#include <ws2tcpip.h>
-//#include <windows.h>
+#include <WS2tcpip.h>
+//#include <Windows.h>
 #else
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Server now also supports specifying libraries without ".lib"